### PR TITLE
改进 clean 命令，支持子文件夹

### DIFF
--- a/grank/libs/helpers.py
+++ b/grank/libs/helpers.py
@@ -363,11 +363,12 @@ def clean_directory():
     for dir in dirs:
         if not os.path.exists(dir):
             continue
-        for file in os.listdir(dir):
-            if os.path.splitext(file)[1] in feature:
-                delete.append(dir + '/' + file)
-                click.echo(dir+'/'+file)
-                exist = True
+        for dirpath,dirnames,filenames in os.walk(dir):
+            for file in filenames:
+                if os.path.splitext(file)[1] in feature:
+                    delete.append(dirpath + '/' + file)
+                    click.echo(dirpath+'/'+file)
+                    exist = True
     if not exist:
     	click.echo("Workspace is empty now!")
     else:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -183,10 +183,10 @@ def test_get_social_average_instance(mocker):
 
 def test_clean_directory(mocker):
     mocker.patch('os.path.exists')
-    mocker.patch('os.listdir')
+    mocker.patch('os.walk')
     helpers.clean_directory()
     os.path.exists.assert_called()
-    os.listdir.assert_called()
+    os.walk.assert_called()
 
 def test_get_config_instance():
     config_temp = configparser.ConfigParser()


### PR DESCRIPTION
修改部分： helpers.py
1. 改进 os.listdir 为使用 os.walk 。使得可以遍历整个目录。

测试：
`
grank clean
result/social_line.png
result/activity_line.png
result/activity_rank.csv
result/social_rank.csv
result/luuming/HomeWork.png
output/social_average.pkl
output/activity_average.pkl
output/social/luuming/HomeWork.csv
output/social/luuming/HomeWork.pkl
output/activity/luuming/HomeWork.csv
output/activity/luuming/HomeWork.pkl

delete these files?(yes/no)
y
done!
`