### PR TITLE
repository_name 为空时跳过

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 变更日志
 
+## 1.0.4
+
+1. core.py 中遍历 repository 时加入对 repository_name 的判断。
+2. 取消 clean 命令对空文件夹删除的代码。
+
 ## 1.0.3
 
 1. 修复 User 可分析 Repo 为 0 时的导致的报错 by @bestony

--- a/grank/core.py
+++ b/grank/core.py
@@ -91,7 +91,9 @@ def analy(args,mode):
             if os.path.exists('output/activity/' + item["owner"] + '/' + item["repository"] + ".csv"):
                 click.echo('跳过')
                 continue
-
+            if item["repository"] == "":
+                click.echo('reporitory name 为空，跳过')
+                continue
             data = crawler.fetch_repo_data(item["owner"], item["repository"], config)
             activity.analyse_repo(item["owner"], item["repository"], data, config)
             social.analyse_email(data,config)

--- a/grank/libs/helpers.py
+++ b/grank/libs/helpers.py
@@ -376,9 +376,6 @@ def clean_directory():
         if confirm in ['yes','y','Yes','Y'] :
             for file in delete:
                 os.remove(file)
-            for dir in dirs:
-                if not os.listdir(dir):
-                    os.rmdir(dir)
             click.echo("done!")
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="Grank",
-    version="1.0.3",
+    version="1.0.4",
     author="LCTT",
     author_email="xiqingongzi@gmail.com",
     python_requires=">=3.4",


### PR DESCRIPTION
## 简单描述你的 PR 内容
<!-- 描述一下你的 PR 中的具体内容 -->
在 core.py 中对 repository 遍历时，加入对 repository_name 的判断。为空时跳过。
删除 clean 命令中对空文件夹清理代码，因为其无法完成存在子文件夹的情况。
<!-- 如果你的 PR 涉及到某个 issue ，请在下方注明 -->


## 其他信息
<!-- 其他你需要说明的内容 -->


## checklist
<!-- 在需要标注完成的方框内加入 x -->

- [ ] 我已经在本地执行了 pytest ，并通过了测试
- [ ] 我已经为我新增的函数添加了测试
- [ ] 我已经更新了 readme.md 中的相关代码
- [x] 我已经根据上方的描述检查了我的项目

